### PR TITLE
fix: generate route tree before typecheck so CI passes

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,13 @@ export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    ignores: ["dist/", "node_modules/", "coverage/"]
+    ignores: ["dist/", "node_modules/", "coverage/", "src/routeTree.gen.ts"]
+  },
+  {
+    files: ["src/components/ui/**/*.tsx"],
+    rules: {
+      "react-refresh/only-export-components": "off"
+    }
   },
   {
     plugins: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "devDependencies": {
         "@eslint/js": "^9.0.0",
         "@tailwindcss/vite": "^4.0.0",
+        "@tanstack/router-cli": "^1.166.7",
         "@tanstack/router-plugin": "^1.166.3",
         "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^16.0.0",
@@ -2695,6 +2696,72 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/router-cli": {
+      "version": "1.166.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-cli/-/router-cli-1.166.7.tgz",
+      "integrity": "sha512-mdrX987vQ5g2BroP0q5CSxPhdISglPZn8RrkMYCks35N7eJd2SElA7bKC/EnuFInSZDQqCKeSHKifK75Mp1Faw==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/router-generator": "1.166.7",
+        "chokidar": "^3.6.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "tsr": "bin/tsr.cjs"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/router-cli/node_modules/@tanstack/router-core": {
+      "version": "1.166.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.166.7.tgz",
+      "integrity": "sha512-MCc8wYIIcxmbeidM8PL2QeaAjUIHyhEDIZPW6NGfn/uwvyi+K2ucn3AGCxxcXl4JGGm0Mx9+7buYl1v3HdcFrg==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/history": "1.161.4",
+        "@tanstack/store": "^0.9.1",
+        "cookie-es": "^2.0.0",
+        "seroval": "^1.4.2",
+        "seroval-plugins": "^1.4.2",
+        "tiny-invariant": "^1.3.3",
+        "tiny-warning": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/router-cli/node_modules/@tanstack/router-generator": {
+      "version": "1.166.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-generator/-/router-generator-1.166.7.tgz",
+      "integrity": "sha512-lBI0VS7J1zMrJhfvT+3FMq9jPdOrJ3VgciPXyYvZBF/a9Mr8T94MU78PqrBNuJbYh7qCFO14ZhArUFqkYGuozQ==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/router-core": "1.166.7",
+        "@tanstack/router-utils": "1.161.4",
+        "@tanstack/virtual-file-routes": "1.161.4",
+        "prettier": "^3.5.0",
+        "recast": "^0.23.11",
+        "source-map": "^0.7.4",
+        "tsx": "^4.19.2",
+        "zod": "^3.24.2"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/router-core": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsr generate && tsc --noEmit && vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsr generate && tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@tailwindcss/vite": "^4.0.0",
+    "@tanstack/router-cli": "^1.166.7",
     "@tanstack/router-plugin": "^1.166.3",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",


### PR DESCRIPTION
## Summary
- Add `@tanstack/router-cli` as dev dependency and run `tsr generate` before `tsc --noEmit` in `typecheck` and `build` scripts — the auto-generated `routeTree.gen.ts` is gitignored so it didn't exist in CI
- Disable `react-refresh/only-export-components` for `src/components/ui/` (shadcn/ui pattern exports both component and variants)
- Add `routeTree.gen.ts` to eslint ignores

## Test plan
- [ ] CI passes (typecheck + lint + tests + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)