### PR TITLE
fix: upgrade eslint-plugin-react-hooks to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.0.0",
         "eslint": "^9.0.0",
-        "eslint-plugin-react-hooks": "^5.0.0",
+        "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.0",
         "jsdom": "^28.1.0",
         "msw": "^2.12.10",
@@ -4575,13 +4575,20 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
@@ -4944,6 +4951,23 @@
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -7759,6 +7783,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.0.0",
     "eslint": "^9.0.0",
-    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.0",
     "jsdom": "^28.1.0",
     "msw": "^2.12.10",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -56,4 +56,5 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 );
 Button.displayName = "Button";
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { Button, buttonVariants };

--- a/src/pages/HealthPage.tsx
+++ b/src/pages/HealthPage.tsx
@@ -33,8 +33,23 @@ export function HealthPage() {
   }, [apiClient]);
 
   useEffect(() => {
-    void checkHealth();
-  }, [checkHealth]);
+    let cancelled = false;
+    apiClient.getHealth().then(
+      (data) => {
+        if (cancelled) return;
+        setHealth(data);
+        setStatus("healthy");
+      },
+      () => {
+        if (cancelled) return;
+        setStatus("unhealthy");
+        setError("Could not reach the API server");
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [apiClient]);
 
   return (
     <div className="mx-auto max-w-lg">


### PR DESCRIPTION
## Summary
- Upgrade `eslint-plugin-react-hooks` from 5.2.0 to 7.0.1
- Fix HealthPage `setState`-in-effect pattern (new v7 rule) by inlining the fetch with cancellation
- Suppress fast-refresh warning on `buttonVariants` export (intentional for template consumers)

Closes #10

## Test plan
- [x] `npm run precommit` passes (format, lint, typecheck, 34 tests)
- [x] Zero lint warnings/errors
- [ ] CI passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)